### PR TITLE
Enable to bump version easily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Changelog
+

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,6 @@ crossbuild: setup
 
 release: package
 	ghr -u aktsk v${VERSION} ./pkg/dist/v${VERSION}
+
+bump:
+	@sh -c "'$(CURDIR)/scripts/bump.sh'"

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+echo current version: $(gobump show -r ./version)
+
+read -p "input next version: " next_version
+
+gobump set $next_version -w ./version
+ghch -w -N v$next_version
+
+git commit -am "Checking in changes prior to tagging of version v$next_version"
+git tag v$next_version
+git push && git push --tags


### PR DESCRIPTION
Executing `make bump` does these things automatically.

* Bump version by [motemen/gobump: Bumps up Go program version](https://github.com/motemen/gobump)
* Update CHANGELOG.md by [Songmu/ghch: Generate changelog from git history, tags and merged pull requests](https://github.com/Songmu/ghch)
* `git commit`
* `git tag`
* `git push --tags`