### PR TITLE
Fix how to build binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ fmt: setup
 	goimports -w .
 
 build:
-	vgo build -o bin/$(NAME) cmd/$(NAME)/main.go
-	vgo build -o bin/$(NAME)-server cmd/$(NAME)-server/main.go
+	cd cmd/kalvados; vgo build -o bin/$(NAME)
+	cd cmd/kalvados-server; vgo build -o bin/$(NAME)-server
 
 clean:
 	rm bin/$(NAME)


### PR DESCRIPTION
With go 1.10.3 and vgo devel +1b870077c8, this error occurs:
build main: cannot find module for path main

Ref golang/go#26798